### PR TITLE
[FIX] mrp_brewing: computing lot_id on sale order

### DIFF
--- a/mrp_brewing/models/sale.py
+++ b/mrp_brewing/models/sale.py
@@ -69,6 +69,6 @@ class SaleOrderLine(models.Model):
 
         for so_line in self:
             moves = so_line.move_ids.filtered(lambda m: m.state == "done")
-            if moves and moves.move_line_ids:
-                lots = moves.move_line_ids.mapped("lot_id")
-                so_line.product_lot_ids = lots
+            move_line_ids = moves.mapped("move_line_ids")
+            lots = move_line_ids.mapped("lot_id")
+            so_line.product_lot_ids = lots

--- a/mrp_brewing/views/sale_views.xml
+++ b/mrp_brewing/views/sale_views.xml
@@ -59,8 +59,7 @@
         <field name="inherit_id" ref="sale.view_order_line_tree" />
         <field name="arch" type="xml">
             <field name="name" position="after">
-                <!-- FIXME: cf. _compute_stock_product -->
-                <!-- <field name="product_lot_ids" widget="many2many_tags" /> -->
+                 <field name="product_lot_ids" widget="many2many_tags" />
                 <field name="effective_date" />
             </field>
         </field>


### PR DESCRIPTION
On sale.order.line several stock.move may be found. Checking`moves.mov_line_ids` failed because of `moves` not being a singleton.

Fixing that using mapped. Also this proposition is not totally the same. Before the field `product_lot_ids` is updated only if there is only one move. Now the field is always updated but with empty value when there is none to set.