### PR TITLE
[IMP] sale_delivery_date: stock_move_date set to now + hide date_done

### DIFF
--- a/sale_delivery_date/__manifest__.py
+++ b/sale_delivery_date/__manifest__.py
@@ -14,6 +14,7 @@
     "data": [
         "views/sale_order_views.xml",
         "views/stock_picking_views.xml",
+        "reports/report_deliveryslip.xml",
     ],
     "installable": True,
 }

--- a/sale_delivery_date/models/stock_picking.py
+++ b/sale_delivery_date/models/stock_picking.py
@@ -15,8 +15,8 @@ class StockPicking(models.Model):
     def action_done(self):
         super(StockPicking, self).action_done()
         for picking in self:
+            if not picking.date_stock_move:
+                picking.date_stock_move = fields.Datetime.now()
+
             for move in picking.move_lines:
-                if picking.date_stock_move:
-                    move.date = picking.date_stock_move
-                else:
-                    move.date = picking.date_done
+                move.date = picking.date_stock_move

--- a/sale_delivery_date/reports/report_deliveryslip.xml
+++ b/sale_delivery_date/reports/report_deliveryslip.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+     Copyright 2021 Coop IT Easy
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <template id="report_delivery_document" inherit_id="stock.report_delivery_document">
+        <xpath expr="//span[@t-field='o.date_done']" position="attributes">
+            <attribute name="invisible">True</attribute>
+        </xpath>
+        <xpath expr="//span[@t-field='o.date_done']" position="after">
+            <span t-field="o.date_stock_move" />
+        </xpath>
+    </template>
+</odoo>

--- a/sale_delivery_date/views/stock_picking_views.xml
+++ b/sale_delivery_date/views/stock_picking_views.xml
@@ -6,6 +6,9 @@
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
+            <field name="date_done" position="attributes">
+                <attribute name="invisible">True</attribute>
+            </field>
             <field name="scheduled_date" position="before">
                 <field name="date_stock_move" />
             </field>


### PR DESCRIPTION
# [task](https://gestion.coopiteasy.be/web#id=6524&view_type=form&model=project.task)

> 1. sur le WH/OUT, si on n'encode rien dans le champ "date of transfer", faire en sorte de mettre la date de "maintenant" (comme c'était le cas en v9 sur le champ "date effective").
Actuellement en v12, si on laisse vide ce champ, il reste vide à la validation, et ça peut être confusing (et à la validation, le champ date effective apparait).

- [x] A la validation du picking, si date_stock_move est vide, je fixe date_stock_move = date_done = now() 

> 2. sur le WH/OUT, toujours cacher le champ "date effective" (même lors de la validation, là où ce champ apparait maintenant).

- [x] ok

> 3. me confirmer que c'est bien la date of transfert qui est utilisée sur les stock moves et donc sur les rapports créés pour les accises.
J'en suis sûre mais je veux revalider

- [x] cf mes notes ci-dessus pour le comportement avant. En codant, 1, 3 est automatique

> 4. Sur le PDF "bon de livraison" qu'on imprime depuis le WH/OUT faire en sorte que la date effective soit remplacé par "date of transfert".
Ou en alternative pour ne rien changer au PDF, on pourrait faire en sorte que "date effective" prenne la valeur de "date of transfer" lors de la validation du WH/OUT.

- [x] date_done invisible, date_stock_move visible à sa place.
