### PR TITLE
[FIX] re-add domain to mrp.production.master_mo_id

### DIFF
--- a/mrp_brewing/models/mrp_production.py
+++ b/mrp_brewing/models/mrp_production.py
@@ -31,6 +31,10 @@ class MrpProduction(models.Model):
     master_mo_id = fields.Many2one(
         comodel_name="mrp.production",
         string="Master MO",
+        domain=[
+            ("product_tmpl_id.is_brewable", "=", True),
+            ("state", "not in", ["draft", "cancel"]),
+        ],
     )
     child_mo_ids = fields.One2many(
         comodel_name="mrp.production",


### PR DESCRIPTION
[task](https://gestion.coopiteasy.be/web#id=7934&view_type=form&model=project.task)

re-add domain to mrp.production.master_mo_id to filter possible values when setting it manually.